### PR TITLE
[Fix] Break the query loop by the next value from opensea

### DIFF
--- a/indexer_ethereum.go
+++ b/indexer_ethereum.go
@@ -193,9 +193,10 @@ func (e *IndexEngine) IndexETHTokenOwners(ctx context.Context, contract, tokenID
 			ownersMap[o.Owner.Address] = o.Quantity
 		}
 
-		if len(owners) < 50 {
+		if n == nil {
 			break
 		}
+
 		next = n
 	}
 


### PR DESCRIPTION
Since opensea returns the nil next value if it is ended, we should use it as a stop condition instead of items counts.

An edge case is that if the owners of a token is exactly divided by 50 (as we set the count), it would running forever.