### PR TITLE
Add video preview file pinning using IPFS

### DIFF
--- a/externals/pinata/client.go
+++ b/externals/pinata/client.go
@@ -1,0 +1,179 @@
+package pinata
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/bitmark-inc/nft-indexer/traceutils"
+)
+
+type PinataAPIClient struct {
+	endpoint  string
+	authToken string
+	client    *http.Client
+}
+
+func New(endpoint, authToken string, timeout time.Duration) *PinataAPIClient {
+	return &PinataAPIClient{
+		endpoint:  endpoint,
+		authToken: authToken,
+		client: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+func (p *PinataAPIClient) makeRequest(method, url string, body io.Reader) *http.Request {
+	req, _ := http.NewRequest(method, url, body)
+
+	req.Header.Add("Content-Type", "application/json")
+
+	if p.authToken != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", p.authToken))
+	}
+
+	return req
+}
+
+type PinnedFile struct {
+	ID       string         `json:"id"`
+	CID      string         `json:"ipfs_pin_hash"`
+	Size     int64          `json:"size"`
+	Metadata PinataMetadata `json:"metadata"`
+}
+
+type PinataMetadata struct {
+	Name string            `json:"name"`
+	KV   map[string]string `json:"keyvalues"`
+}
+
+type PinHashRequest struct {
+	CID      string          `json:"hashToPin"`
+	Metadata *PinataMetadata `json:"pinataMetadata,omitempty"`
+}
+
+// PinnedFile returns the pinned file for a given CID
+func (p *PinataAPIClient) PinnedFile(cid string) (*PinnedFile, error) {
+	u := url.URL{
+		Scheme:   "https",
+		Host:     p.endpoint,
+		Path:     "/data/pinList",
+		RawQuery: fmt.Sprintf("hashContains=%s", cid),
+	}
+
+	req := p.makeRequest("GET", u.String(), nil)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		fmt.Println(traceutils.DumpRequest(req))
+		fmt.Println(traceutils.DumpResponse(resp))
+		return nil, errors.New("http status not 200")
+	}
+
+	var result struct {
+		Count int64        `json:"count"`
+		Rows  []PinnedFile `json:"rows"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	if result.Count == 0 {
+		return nil, nil
+	}
+
+	return &result.Rows[0], nil
+}
+
+// PinJobs gets all pinning jobs
+func (p *PinataAPIClient) PinJobs(cid string) (*PinByHashResp, error) {
+	u := url.URL{
+		Scheme:   "https",
+		Host:     p.endpoint,
+		Path:     "/pinning/pinJobs",
+		RawQuery: fmt.Sprintf("ipfs_pin_hash=%s", cid),
+	}
+
+	req := p.makeRequest("GET", u.String(), nil)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		fmt.Println(traceutils.DumpRequest(req))
+		fmt.Println(traceutils.DumpResponse(resp))
+		return nil, errors.New("http status not 200")
+	}
+
+	var result struct {
+		Count int64           `json:"count"`
+		Rows  []PinByHashResp `json:"rows"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	if result.Count == 0 {
+		return nil, nil
+	}
+
+	return &result.Rows[0], nil
+}
+
+type PinByHashResp struct {
+	ID     string `json:"id"`
+	CID    string `json:"ipfsHash"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+// PinByHash makes a pin request to pinata
+func (p *PinataAPIClient) PinByHash(cid string, metadata *PinataMetadata) (*PinByHashResp, error) {
+	u := url.URL{
+		Scheme: "https",
+		Host:   p.endpoint,
+		Path:   "/pinning/pinByHash",
+	}
+
+	reqBody := PinHashRequest{
+		CID:      cid,
+		Metadata: metadata,
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(reqBody); err != nil {
+		return nil, err
+	}
+
+	req := p.makeRequest("POST", u.String(), &body)
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		fmt.Println(traceutils.DumpRequest(req))
+		fmt.Println(traceutils.DumpResponse(resp))
+		return nil, errors.New("http status not 200")
+	}
+
+	var result PinByHashResp
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/services/nft-image-indexer/config.yaml.sample
+++ b/services/nft-image-indexer/config.yaml.sample
@@ -12,3 +12,6 @@ store:
 
 log:
   level: info
+
+pinata:
+  jwt:

--- a/services/nft-image-indexer/ipfs.go
+++ b/services/nft-image-indexer/ipfs.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"time"
+
+	"github.com/bitmark-inc/nft-indexer/externals/pinata"
+	"github.com/spf13/viper"
+)
+
+// PinnedFile defines functions of IPFSPinService
+type IPFSPinService interface {
+	Pin(cid string) (bool, error)
+}
+
+// PinataIPFSPinService is an IPFSPinService implementation using pinata
+type PinataIPFSPinService struct {
+	client *pinata.PinataAPIClient
+}
+
+func NewPinataIPFSPinService() *PinataIPFSPinService {
+	return &PinataIPFSPinService{
+		client: pinata.New("api.pinata.cloud", viper.GetString("pinata.jwt"), 10*time.Second),
+	}
+}
+
+// Pin a file to IPFS through a CID
+func (p *PinataIPFSPinService) Pin(cid string) (bool, error) {
+	pinnedFile, err := p.client.PinnedFile(cid)
+	if err != nil {
+		return false, err
+	}
+
+	// file has already pinned
+	if pinnedFile != nil {
+		return true, nil
+	}
+
+	job, err := p.client.PinJobs(cid)
+	if err != nil {
+		return false, err
+	}
+
+	// the file is pinning
+	if job != nil {
+		return false, nil
+	}
+
+	_, err = p.client.PinByHash(cid, nil)
+	return false, err
+}

--- a/services/nft-image-indexer/service.go
+++ b/services/nft-image-indexer/service.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,15 +30,16 @@ type NFTContentIndexer struct {
 	nftAssets *mongo.Collection
 }
 
-func NewNFTContentIndexer(db *imageStore.ImageStore, nftAssets *mongo.Collection) *NFTContentIndexer {
+func NewNFTContentIndexer(db *imageStore.ImageStore, nftAssets *mongo.Collection, ipfs IPFSPinService) *NFTContentIndexer {
 	return &NFTContentIndexer{
 		db:        db,
+		ipfs:      ipfs,
 		nftAssets: nftAssets,
 	}
 }
 
-// spawnWorker spawn worker for generate thumbnails from source images
-func (s *NFTContentIndexer) spawnWorker(ctx context.Context, assets <-chan NFTAsset, count int) {
+// spawnThumbnailWorker spawn worker for generate thumbnails from source images
+func (s *NFTContentIndexer) spawnThumbnailWorker(ctx context.Context, assets <-chan NFTAsset, count int) {
 	for i := 0; i < count; i++ {
 		s.wg.Add(1)
 		go func() {
@@ -70,6 +73,46 @@ func (s *NFTContentIndexer) spawnWorker(ctx context.Context, assets <-chan NFTAs
 
 				logrus.WithField("indexID", asset.IndexID).Info("thumbnail generating process finished")
 			}
+			logrus.Debug("ThumbnailWorker stopped")
+		}()
+	}
+}
+
+// spawnIPFSPinWorker spawn worker to pin preview file of assets to IPFS
+func (s *NFTContentIndexer) spawnIPFSPinWorker(ctx context.Context, assets <-chan NFTAsset, count int) {
+	for i := 0; i < count; i++ {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+
+			for asset := range assets {
+				previewURL := asset.ProjectMetadata.Latest.PreviewURL
+				if strings.HasPrefix(previewURL, "https://ipfs.io/ipfs/") {
+					ipfsCIDPath := strings.ReplaceAll(previewURL, "https://ipfs.io/ipfs/", "")
+
+					if ipfsCIDPath == "" {
+						logrus.WithField("previewURL", previewURL).Error("incorrect file path")
+						continue
+					}
+
+					cid := strings.Split(ipfsCIDPath, "/")[0]
+
+					if _, err := s.ipfs.Pin(cid); err != nil {
+						logrus.WithField("previewURL", previewURL).WithError(err).Error("fail to pin a file into IPFS")
+						fmt.Println("www", indexer.SleepWithContext(ctx, 30*time.Second))
+						continue
+					}
+
+					if err := s.updateTokenPinnedStatus(ctx, asset.IndexID); err != nil {
+						logrus.WithError(err).Error("fail to update pin status for a token")
+					}
+
+					logrus.WithField("indexID", asset.IndexID).Info("preview url has pinned")
+				} else {
+					logrus.WithField("previewURL", previewURL).Warn("unsupported preview url")
+				}
+			}
+			logrus.Debug("IPFSPinWorker stopped")
 		}()
 	}
 }
@@ -79,7 +122,6 @@ func (s *NFTContentIndexer) getAssetWithoutThumbnailCached(ctx context.Context) 
 	var asset NFTAsset
 	r := s.nftAssets.FindOneAndUpdate(ctx,
 		bson.M{
-			"indexID":                             bson.M{"$exists": true},
 			"thumbnailID":                         bson.M{"$exists": false},
 			"projectMetadata.latest.thumbnailURL": bson.M{"$ne": ""},
 			"$or": bson.A{
@@ -105,6 +147,39 @@ func (s *NFTContentIndexer) getAssetWithoutThumbnailCached(ctx context.Context) 
 	return asset, err
 }
 
+// getAssetWithoutIPFSPinned looks up assets without ipfs pinned
+func (s *NFTContentIndexer) getAssetWithoutIPFSPinned(ctx context.Context) (NFTAsset, error) {
+	var asset NFTAsset
+	r := s.nftAssets.FindOneAndUpdate(ctx,
+		bson.M{
+			"ipfsPinned":                        bson.M{"$ne": true},
+			"source":                            indexer.SourceTZKT,
+			"projectMetadata.latest.previewURL": bson.M{"$ne": ""},
+			"projectMetadata.latest.medium":     indexer.MediumVideo,
+			"projectMetadata.latest.mimeType":   bson.M{"$eq": "video/webm"},
+			"$or": bson.A{
+				bson.M{
+					"ipfsPinnedLastCheck": bson.M{"$exists": false},
+				},
+				bson.M{
+					"ipfsPinnedLastCheck": bson.M{"$lt": time.Now().Add(-1 * time.Minute)},
+				},
+			},
+		},
+		bson.M{"$set": bson.M{"ipfsPinnedLastCheck": time.Now()}},
+		options.FindOneAndUpdate().SetProjection(
+			bson.M{"indexID": 1, "projectMetadata.latest.previewURL": 1},
+		),
+	)
+
+	if err := r.Err(); err != nil {
+		return asset, err
+	}
+
+	err := r.Decode(&asset)
+	return asset, err
+}
+
 // updateTokenThumbnail sets the thumbnail id for a specific token
 func (s *NFTContentIndexer) updateTokenThumbnail(ctx context.Context, indexID, thumbnailID string) error {
 	_, err := s.nftAssets.UpdateOne(
@@ -116,11 +191,28 @@ func (s *NFTContentIndexer) updateTokenThumbnail(ctx context.Context, indexID, t
 	return err
 }
 
-func (s *NFTContentIndexer) Start(ctx context.Context) {
-	for {
-		assets := make(chan NFTAsset, 200)
-		s.spawnWorker(ctx, assets, 100)
+// updateTokenPinnedStatus sets a specific token to be pinned
+func (s *NFTContentIndexer) updateTokenPinnedStatus(ctx context.Context, indexID string) error {
+	_, err := s.nftAssets.UpdateOne(
+		ctx,
+		bson.M{"indexID": indexID},
+		bson.D{{"$set", bson.D{{"ipfsPinned", true}}}},
+	)
 
+	return err
+}
+
+func (s *NFTContentIndexer) checkThumbnail(ctx context.Context) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		assets := make(chan NFTAsset, 200)
+		defer close(assets)
+
+		s.spawnThumbnailWorker(ctx, assets, 100)
+
+	WATCH_ASSETS:
 		for {
 			asset, err := s.getAssetWithoutThumbnailCached(ctx)
 			if err != nil {
@@ -130,12 +222,56 @@ func (s *NFTContentIndexer) Start(ctx context.Context) {
 					logrus.WithError(err).Error("fail to get asset")
 				}
 
-				// FIXME: add config for thumbnail checking interval
-				time.Sleep(time.Minute)
+				if done := indexer.SleepWithContext(ctx, 15*time.Second); done {
+					break WATCH_ASSETS
+				}
 				continue
 			}
 			logrus.WithField("indexID", asset.IndexID).Debug("send asset to process")
 			assets <- asset
 		}
-	}
+		logrus.Debug("Thumbnail checker closed")
+	}()
+
+}
+
+// checkIPFSPinned starts workers to check and pin files to IPFS
+func (s *NFTContentIndexer) checkIPFSPinned(ctx context.Context) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		assets := make(chan NFTAsset, 50)
+		defer close(assets)
+
+		s.spawnIPFSPinWorker(ctx, assets, 1)
+
+	WATCH_ASSETS:
+		for {
+			asset, err := s.getAssetWithoutIPFSPinned(ctx)
+			if err != nil {
+				if errors.Is(err, mongo.ErrNoDocuments) {
+					logrus.Info("No token need to pin IPFS")
+				} else {
+					logrus.WithError(err).Error("fail to get asset")
+				}
+
+				if done := indexer.SleepWithContext(ctx, 15*time.Second); done {
+					break WATCH_ASSETS
+				}
+
+				continue
+			}
+
+			logrus.WithField("indexID", asset.IndexID).Debug("send asset to process")
+			assets <- asset
+		}
+		logrus.Debug("IPFS-pinned checker closed")
+	}()
+}
+
+func (s *NFTContentIndexer) Start(ctx context.Context) {
+	s.checkThumbnail(ctx)
+	s.checkIPFSPinned(ctx)
+	s.wg.Wait()
 }

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,11 @@
 package indexer
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -77,5 +79,16 @@ func TxURL(blockchain, network, txID string) string {
 		return fmt.Sprintf("https://etherscan.io/tx/%s", txID)
 	default:
 		return ""
+	}
+}
+
+// SleepWithContext will return whenever the slept time reached or context done
+// It returns true if the context is done
+func SleepWithContext(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-time.After(d):
+		return false
+	case <-ctx.Done():
+		return true
 	}
 }


### PR DESCRIPTION
In this PR, it introduces an IPFS pinning function using pinata.

## Goal

For video files with specific format, we will pin it over pinata and update the asset record to set `ipfsPinned = true`

### Changes

- add an API wrapper for pinata
- add a worker for IPFS pinning
- improve the graceful shutdown