### PR TITLE
Add network support for tezos tokens into nft indexer

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -8,6 +8,7 @@ import (
 )
 
 type IndexEngine struct {
+	network string
 	opensea *opensea.OpenseaClient
 	tzkt    *tzkt.TZKT
 	fxhash  *fxhash.FxHashAPI
@@ -15,12 +16,14 @@ type IndexEngine struct {
 }
 
 func New(
+	network string,
 	opensea *opensea.OpenseaClient,
 	tzkt *tzkt.TZKT,
 	fxhash *fxhash.FxHashAPI,
 	objkt *objkt.ObjktAPI,
 ) *IndexEngine {
 	return &IndexEngine{
+		network: network,
 		opensea: opensea,
 		tzkt:    tzkt,
 		fxhash:  fxhash,

--- a/externals/tzkt/client.go
+++ b/externals/tzkt/client.go
@@ -17,7 +17,12 @@ type TZKT struct {
 	client *http.Client
 }
 
-func New(endpoint string) *TZKT {
+func New(network string) *TZKT {
+	endpoint := "api.mainnet.tzkt.io"
+	if network == "testnet" {
+		endpoint = "api.ghostnet.tzkt.io"
+	}
+
 	return &TZKT{
 		client: &http.Client{
 			Timeout: 15 * time.Second,

--- a/externals/tzkt/client_test.go
+++ b/externals/tzkt/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetContractToken(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	token, err := tc.GetContractToken("KT1LjmAdYQCLBjwv4S2oFkEzyHVkomAf5MrW", "24216")
 	assert.NoError(t, err)
@@ -24,7 +24,7 @@ func TestGetContractToken(t *testing.T) {
 }
 
 func TestRetrieveTokens(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	ownedTokens, err := tc.RetrieveTokens("tz1RBi5DCVBYh1EGrcoJszkte1hDjrFfXm5C", 0)
 	assert.NoError(t, err)
@@ -33,7 +33,7 @@ func TestRetrieveTokens(t *testing.T) {
 }
 
 func TestGetTokenTransfers(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	transfers, err := tc.GetTokenTransfers("KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi", "905625")
 	assert.NoError(t, err)
@@ -49,7 +49,7 @@ func TestGetTokenTransfers(t *testing.T) {
 }
 
 func TestGetTransaction(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	transaction, err := tc.GetTransaction(123186632)
 	assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestGetTransaction(t *testing.T) {
 }
 
 func TestGetTokenActivityTime(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	activityTime, err := tc.GetTokenLastActivityTime("KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi", "905625")
 	assert.NoError(t, err)
@@ -67,7 +67,7 @@ func TestGetTokenActivityTime(t *testing.T) {
 }
 
 func TestGetTokenActivityTimeNotExist(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	activityTime, err := tc.GetTokenLastActivityTime("KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi", "0")
 	assert.Error(t, err, "no activities for this token")
@@ -75,7 +75,7 @@ func TestGetTokenActivityTimeNotExist(t *testing.T) {
 }
 
 func TestGetTokenBalanceForOwner(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	owner, err := tc.GetTokenBalanceForOwner("KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton", "751194", "tz1bpvbjRGW1XHkALp4hFee6PKbnZCcoN9hE")
 	assert.NoError(t, err)
@@ -83,7 +83,7 @@ func TestGetTokenBalanceForOwner(t *testing.T) {
 }
 
 func TestGetArtworkMIMEType(t *testing.T) {
-	tc := New("api.mainnet.tzkt.io")
+	tc := New("")
 
 	token, err := tc.GetContractToken("KT1XXcp2U2vAn4dENmKjJkyYb8svTEf2DxTY", "0")
 	assert.NoError(t, err)

--- a/indexer_tezos.go
+++ b/indexer_tezos.go
@@ -103,60 +103,62 @@ func (e *IndexEngine) indexTezosToken(ctx context.Context, t tzkt.Token, owner s
 		MintedAt: t.Timestamp,
 	}
 
-	switch t.Contract.Address {
-	case KALAMContractAddress, TezDaoContractAddress, TezosDNSContractAddress:
-		return nil, nil
+	if e.network != "testnet" {
+		switch t.Contract.Address {
+		case KALAMContractAddress, TezDaoContractAddress, TezosDNSContractAddress:
+			return nil, nil
 
-	case FXHASHV2ContractAddress, FXHASHContractAddress, FXHASHOldContractAddress:
-		metadataDetail.SetMarketplace(
-			MarketplaceProfile{
-				"fxhash",
-				"https://www.fxhash.xyz",
-				fmt.Sprintf("https://www.fxhash.xyz/gentk/%s", t.ID.String()),
-			},
-		)
-		metadataDetail.SetMedium(MediumSoftware)
+		case FXHASHV2ContractAddress, FXHASHContractAddress, FXHASHOldContractAddress:
+			metadataDetail.SetMarketplace(
+				MarketplaceProfile{
+					"fxhash",
+					"https://www.fxhash.xyz",
+					fmt.Sprintf("https://www.fxhash.xyz/gentk/%s", t.ID.String()),
+				},
+			)
+			metadataDetail.SetMedium(MediumSoftware)
 
-		if detail, err := e.fxhash.GetObjectDetail(ctx, t.ID.Int); err != nil {
-			log.WithError(err).Error("fail to get token detail from fxhash")
-		} else {
-			metadataDetail.FromFxhashObject(detail)
-			tokenDetail.MintedAt = detail.CreatedAt
-			tokenDetail.Edition = detail.Iteration
-		}
-	case VersumContractAddress:
-		tokenDetail.Fungible = true
-		metadataDetail.SetMarketplace(MarketplaceProfile{"versum", "https://versum.xyz",
-			fmt.Sprintf("https://versum.xyz/token/versum/%s", t.ID.String())},
-		)
+			if detail, err := e.fxhash.GetObjectDetail(ctx, t.ID.Int); err != nil {
+				log.WithError(err).Error("fail to get token detail from fxhash")
+			} else {
+				metadataDetail.FromFxhashObject(detail)
+				tokenDetail.MintedAt = detail.CreatedAt
+				tokenDetail.Edition = detail.Iteration
+			}
+		case VersumContractAddress:
+			tokenDetail.Fungible = true
+			metadataDetail.SetMarketplace(MarketplaceProfile{"versum", "https://versum.xyz",
+				fmt.Sprintf("https://versum.xyz/token/versum/%s", t.ID.String())},
+			)
 
-		metadataDetail.ArtistURL = fmt.Sprintf("https://versum.xyz/user/%s", metadataDetail.ArtistName)
+			metadataDetail.ArtistURL = fmt.Sprintf("https://versum.xyz/user/%s", metadataDetail.ArtistName)
 
-	case HicEtNuncContractAddress:
-		tokenDetail.Fungible = true
-		// hicetnunc is down. We now fallback the source url and asset url to objkt.com
-		metadataDetail.SetMarketplace(MarketplaceProfile{"hic et nunc", "https://objkt.com",
-			fmt.Sprintf("https://objkt.com/asset/%s/%s", t.Contract.Address, t.ID.String())},
-		)
-	default:
-		tokenDetail.Fungible = true
-		// fallback marketplace
-		metadataDetail.SetMarketplace(MarketplaceProfile{"unknown", "https://objkt.com",
-			fmt.Sprintf("https://objkt.com/asset/%s/%s", t.Contract.Address, t.ID.String())},
-		)
-
-		if t.Metadata.Symbol == "OBJKTCOM" {
-			metadataDetail.SetMarketplace(MarketplaceProfile{"objkt", "https://objkt.com",
+		case HicEtNuncContractAddress:
+			tokenDetail.Fungible = true
+			// hicetnunc is down. We now fallback the source url and asset url to objkt.com
+			metadataDetail.SetMarketplace(MarketplaceProfile{"hic et nunc", "https://objkt.com",
 				fmt.Sprintf("https://objkt.com/asset/%s/%s", t.Contract.Address, t.ID.String())},
 			)
-		}
-		// if detail, err := e.objkt.GetObjktDetailed(ctx, t.ID.Text(10), t.Contract.Address); err != nil {
-		// 	log.WithError(err).Error("fail to get token detail from objkt")
-		// } else {
+		default:
+			tokenDetail.Fungible = true
+			// fallback marketplace
+			metadataDetail.SetMarketplace(MarketplaceProfile{"unknown", "https://objkt.com",
+				fmt.Sprintf("https://objkt.com/asset/%s/%s", t.Contract.Address, t.ID.String())},
+			)
 
-		// 	metadataDetail.FromObjktObject(detail)
-		// 	tokenDetail.MintedAt = detail.MintedAt
-		// }
+			if t.Metadata.Symbol == "OBJKTCOM" {
+				metadataDetail.SetMarketplace(MarketplaceProfile{"objkt", "https://objkt.com",
+					fmt.Sprintf("https://objkt.com/asset/%s/%s", t.Contract.Address, t.ID.String())},
+				)
+			}
+			// if detail, err := e.objkt.GetObjktDetailed(ctx, t.ID.Text(10), t.Contract.Address); err != nil {
+			// 	log.WithError(err).Error("fail to get token detail from objkt")
+			// } else {
+
+			// 	metadataDetail.FromObjktObject(detail)
+			// 	tokenDetail.MintedAt = detail.MintedAt
+			// }
+		}
 	}
 
 	pm := ProjectMetadata{

--- a/indexer_tezos_test.go
+++ b/indexer_tezos_test.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,23 +10,28 @@ import (
 )
 
 func TestIndexTezosTokenProvenance(t *testing.T) {
-	engine := New(nil, tzkt.New("api.mainnet.tzkt.io"), nil, nil)
+	engine := New("", nil, tzkt.New(""), nil, nil)
 	provenances, err := engine.IndexTezosTokenProvenance(context.Background(), "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE", "178227")
 	assert.NoError(t, err)
-
-	b, _ := json.MarshalIndent(provenances, "", "  ")
-	t.Log(string(b))
+	assert.Len(t, provenances, 6)
 }
 
 func TestIndexTezosTokenOwnersWithNFT(t *testing.T) {
-	engine := New(nil, tzkt.New("api.mainnet.tzkt.io"), nil, nil)
+	engine := New("", nil, tzkt.New(""), nil, nil)
 	owners, err := engine.IndexTezosTokenOwners(context.Background(), "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE", "178227")
 	assert.NoError(t, err)
 	assert.Len(t, owners, 1)
 }
 
+func TestGetTezosTokenByOwner(t *testing.T) {
+	engine := New("", nil, tzkt.New(""), nil, nil)
+	owners, err := engine.GetTezosTokenByOwner(context.Background(), "tz1YiYx6TwBnsAgEnXSyhFiM9bqFD54QVhy4", 0) // incorrect metadata format case
+	assert.NoError(t, err)
+	assert.NotEmpty(t, owners)
+}
+
 func TestIndexTezosTokenOwnersFT(t *testing.T) {
-	engine := New(nil, tzkt.New("api.mainnet.tzkt.io"), nil, nil)
+	engine := New("", nil, tzkt.New(""), nil, nil)
 	owners, err := engine.IndexTezosTokenOwners(context.Background(), "KT1LjmAdYQCLBjwv4S2oFkEzyHVkomAf5MrW", "24216")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, owners)

--- a/services/nft-event-subscriber/main.go
+++ b/services/nft-event-subscriber/main.go
@@ -96,8 +96,9 @@ func main() {
 	}
 
 	engine := indexer.New(
-		opensea.New(viper.GetString("network"), viper.GetString("opensea.api_key"), viper.GetInt("opensea.ratelimit")),
-		tzkt.New("api.mainnet.tzkt.io"),
+		network,
+		opensea.New(network, viper.GetString("opensea.api_key"), viper.GetInt("opensea.ratelimit")),
+		tzkt.New(network),
 		fxhash.New(viper.GetString("fxhash.api_endpoint")),
 		objkt.New(viper.GetString("objkt.api_endpoint")),
 	)

--- a/services/nft-indexer-background/main.go
+++ b/services/nft-indexer-background/main.go
@@ -46,8 +46,9 @@ func main() {
 	}
 
 	indexerEngine := indexer.New(
-		opensea.New(viper.GetString("network"), viper.GetString("opensea.api_key"), viper.GetInt("opensea.ratelimit")),
-		tzkt.New("api.mainnet.tzkt.io"),
+		network,
+		opensea.New(network, viper.GetString("opensea.api_key"), viper.GetInt("opensea.ratelimit")),
+		tzkt.New(network),
 		fxhash.New(viper.GetString("fxhash.api_endpoint")),
 		objkt.New(viper.GetString("objkt.api_endpoint")),
 	)

--- a/services/nft-indexer/main.go
+++ b/services/nft-indexer/main.go
@@ -25,9 +25,11 @@ func main() {
 
 	config.LoadConfig("NFT_INDEXER")
 
+	network := viper.GetString("network")
+
 	if err := sentry.Init(sentry.ClientOptions{
 		Dsn:         viper.GetString("sentry.dsn"),
-		Environment: viper.GetString("network"),
+		Environment: network,
 	}); err != nil {
 		log.WithError(err).Panic("Sentry initialization failed")
 	}
@@ -45,8 +47,9 @@ func main() {
 	feralfileClient := feralfile.New(viper.GetString("feralfile.api_url"))
 
 	engine := indexer.New(
-		opensea.New(viper.GetString("network"), viper.GetString("opensea.api_key"), viper.GetInt("opensea.ratelimit")),
-		tzkt.New("api.mainnet.tzkt.io"),
+		network,
+		opensea.New(network, viper.GetString("opensea.api_key"), viper.GetInt("opensea.ratelimit")),
+		tzkt.New(network),
 		fxhash.New(viper.GetString("fxhash.api_endpoint")),
 		objkt.New(viper.GetString("objkt.api_endpoint")),
 	)


### PR DESCRIPTION
In this PR, it introduces testnet support for tezos blockchain.

### Changes

- use `api.ghostnet.tzkt.io` if the network == `testnet`
- ignore marketplace update when the network is in testnet