### PR TITLE
Add [] to formats if this field is not an array

### DIFF
--- a/externals/tzkt/client.go
+++ b/externals/tzkt/client.go
@@ -57,6 +57,14 @@ func (f *FileFormats) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(d, (*formats)(f)); err != nil {
 			return err
 		}
+	case 123: // If the "formats" is not an array
+		d := append([]byte{91}, data...)
+		if data[len(data)-1] != 93 {
+			d = append(d, []byte{93}...)
+		}
+		if err := json.Unmarshal(d, (*formats)(f)); err != nil {
+			return err
+		}
 	default:
 		if err := json.Unmarshal(data, (*formats)(f)); err != nil {
 			return err


### PR DESCRIPTION
This PR solves the issue [#1553](https://github.com/bitmark-inc/autonomy/issues/1553).
Need to wrap the value of `formats` into `[]`.