### PR TITLE
Fix/remove empty string for pending tx

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -143,5 +143,5 @@ type AccountToken struct {
 	LastRefreshedTime time.Time        `json:"lastRefreshedTime" bson:"lastRefreshedTime"`
 	RunID             string           `json:"-" bson:"runID"`
 
-	PendingTx string `json:"pendingTx" bson:"pendingTx"`
+	PendingTx *string `json:"pendingTx,omitempty" bson:"pendingTx,omitempty"`
 }


### PR DESCRIPTION
**Description**

This PR is to remove redundant empty string from `account_tokens`
