### PR TITLE
[background] if preview enabled and fails return its error code

### DIFF
--- a/background/indexerWorker/workflows.go
+++ b/background/indexerWorker/workflows.go
@@ -171,6 +171,7 @@ func (w *NFTIndexerWorker) IndexTokenWorkflow(ctx workflow.Context, owner, contr
 	if indexPreview {
 		if err := workflow.ExecuteActivity(ctx, w.CacheIPFSArtifactInS3, update.ProjectMetadata.PreviewURL).Get(ctx, nil); err != nil {
 			sentry.CaptureException(err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
currently the workflow ignores preview errors. This relates to blank entries appearing in the Autonomy APP Discovery feed.

- the feed server needs to be sure a preview is available when indexing completes to prevent adding blank entries to the feed
- failed indexing is used to triggers a retry of this workflow, but currently preview failure will return success
