### PR TITLE
Use LastRefreshedTime for update pending tokens

### DIFF
--- a/indexer_ethereum.go
+++ b/indexer_ethereum.go
@@ -161,12 +161,13 @@ func (e *IndexEngine) indexETHToken(a *opensea.Asset, owner string, balance int6
 					ContractType:    contractType,
 					ContractAddress: contractAddress,
 				},
-				IndexID: TokenIndexID(EthereumBlockchain, contractAddress, a.TokenID),
-				Edition: 0,
-				Balance: balance,
-				Owner:   owner,
-				Owners:  map[string]int64{owner: balance},
-				MintAt:  a.AssetContract.CreatedDate.Time, // set minted_at to the contract creation time
+				IndexID:           TokenIndexID(EthereumBlockchain, contractAddress, a.TokenID),
+				Edition:           0,
+				Balance:           balance,
+				Owner:             owner,
+				Owners:            map[string]int64{owner: balance},
+				MintAt:            a.AssetContract.CreatedDate.Time, // set minted_at to the contract creation time
+				LastRefreshedTime: time.Now(),
 			},
 		},
 	}

--- a/store.go
+++ b/store.go
@@ -972,8 +972,8 @@ func (s *MongodbIndexerStore) UpdateAccountTokenBalance(ctx context.Context, own
 			"indexID":      indexID,
 			"ownerAccount": ownerAccount,
 			"$or": bson.A{
-				bson.M{"lastActivityTime": bson.M{"$lt": transactionTime}},
-				bson.M{"lastActivityTime": bson.M{"$exists": false}},
+				bson.M{"lastRefreshedTime": bson.M{"$lt": transactionTime}},
+				bson.M{"lastRefreshedTime": bson.M{"$exists": false}},
 			},
 		},
 		bson.M{

--- a/structs.go
+++ b/structs.go
@@ -78,7 +78,7 @@ type Token struct {
 	Burned            bool         `json:"burned" bson:"burned"`
 	Provenances       []Provenance `json:"provenance" bson:"provenance"`
 	LastActivityTime  time.Time    `json:"lastActivityTime" bson:"lastActivityTime"`
-	LastRefreshedTime time.Time    `json:"-" bson:"lastRefreshedTime"`
+	LastRefreshedTime time.Time    `json:"lastRefreshedTime" bson:"lastRefreshedTime"`
 }
 
 type ProjectMetadata struct {


### PR DESCRIPTION
The new token is indexed with zero `LastRefreshedTime` and `LastActivityTime` which makes its balance is changed by any pendingTx.

We need to set `LastRefresedTime` as now and compare it with transaction time while we update the pending account tokens.