### PR TITLE
Fix default ipfs links from tzkt

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -188,8 +188,8 @@ func (detail *AssetMetadataDetail) UpdateMetadataFromTZKT(md tzkt.TokenMetadata)
 		previewURI = displayURI
 	}
 
-	detail.DisplayURI = displayURI
-	detail.PreviewURI = previewURI
+	detail.DisplayURI = defaultIPFSLink(displayURI)
+	detail.PreviewURI = defaultIPFSLink(previewURI)
 }
 
 // FromFxhashObject reads asset detail from an fxhash API object


### PR DESCRIPTION
**Description**

- Description:
  - In some cases the `thumbnailURL` and `previewURL` will fallback to `ipfs://`  instead of `https://ipfs.io/`

- Reason:
  - In function `UpdateMetadataFromTZKT` we don’t convert the link to `https://ipfs.io/`
 
- Fix: 
  - Use `defaultIPFSLink()` to convert the links