### PR TITLE
Increase ExecutionStartToCloseTimeout and improve workflow loop

### DIFF
--- a/background/indexerWorker/helper.go
+++ b/background/indexerWorker/helper.go
@@ -81,7 +81,8 @@ func StartUpdateAccountTokensWorkflow(c context.Context, client *cadence.Cadence
 	workflowContext := cadenceClient.StartWorkflowOptions{
 		ID:                           "update-account-token-helper",
 		TaskList:                     AccountTokenTaskListName,
-		ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour, // fake infinite duration
+		ExecutionStartToCloseTimeout: time.Hour,
+		CronSchedule:                 "* * * * *", //every minute
 		WorkflowIDReusePolicy:        cadenceClient.WorkflowIDReusePolicyAllowDuplicate,
 	}
 

--- a/background/indexerWorker/workflows.go
+++ b/background/indexerWorker/workflows.go
@@ -259,7 +259,6 @@ func (w *NFTIndexerWorker) CacheIPFSArtifactWorkflow(ctx workflow.Context, fullD
 
 // UpdateAccountTokenWorkflow is a workflow to refresh provenance for a specific token
 func (w *NFTIndexerWorker) UpdateAccountTokensWorkflow(ctx workflow.Context, delay time.Duration) error {
-	var err error
 	ao := workflow.ActivityOptions{
 		TaskList:               w.AccountTokenTaskListName,
 		ScheduleToStartTimeout: 10 * time.Minute,
@@ -272,18 +271,12 @@ func (w *NFTIndexerWorker) UpdateAccountTokensWorkflow(ctx workflow.Context, del
 
 	log.Debug("start UpdateAccountTokensWorkflow")
 
-	err = workflow.ExecuteActivity(ctx, w.UpdateAccountTokens).Get(ctx, nil)
-	if err != nil {
+	if err := workflow.ExecuteActivity(ctx, w.UpdateAccountTokens).Get(ctx, nil); err != nil {
 		log.Error("fail to update account tokens")
 		return err
 	}
 
-	err = workflow.Sleep(ctx, 1*time.Minute)
-	if err != nil {
-		log.Error("fail to sleep")
-	}
-
-	return workflow.NewContinueAsNewError(ctx, w.UpdateAccountTokensWorkflow, delay)
+	return nil
 }
 
 // UpdateSuggestedMimeTypeWorkflow is a workflow to update suggested mimeType from token feedback


### PR DESCRIPTION
**Description**
`UpdateAccountTokensWorkflow` is terminated after 1 hour. We need to increase this time.
Besides, using big `for` loop for a workflow will keep its history growing. Should use `Continue as new`


**Describe your changes**

- [ ] increase `ExecutionStartToCloseTimeout` to 20 years (a fake infinite duration)
- [ ] substitute a big for loop by `Continue as new`
