### PR TITLE
Fix ipfs link

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -344,7 +344,7 @@ func (d *AssetMetadataDetail) ReplaceIPFSURIByObjktCDNURI(assetType, assetUri, c
 		return uri
 	}
 
-	return assetUri
+	return defaultIPFSLink(assetUri)
 }
 
 // MakeCDNURIFromIPFSURI create Objkt CDN uri from IPFS Uri(extract cid)
@@ -401,5 +401,5 @@ func MakeCDNURIFromIPFSURI(assetURI, assetType, contract, tokenID string) (strin
 		}
 	}
 
-	return assetURI, nil
+	return defaultIPFSLink(assetURI), nil
 }

--- a/indexer_tezos_test.go
+++ b/indexer_tezos_test.go
@@ -83,6 +83,11 @@ func TestIndexTezosToken(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, strings.Contains(assetUpdates.ProjectMetadata.ArtistName, "tz1bWudFpgfnyknWa6MVjYH5VJbA3d9PHpma"), true)
 
+	assetUpdates, err = engine.IndexTezosToken(context.Background(), "KT1FvqJwEDWb1Gwc55Jd1jjTHRVWbYKUUpyq", "KT18pVpRXKPY2c4U2yFEGSH3ZnhB2kL8kwXS", "3164")
+	assert.NoError(t, err)
+	assert.Equal(t, strings.Contains(assetUpdates.ProjectMetadata.PreviewURL, "https://assets.objkt.media/file/assets-003/"), true)
+	assert.Equal(t, strings.Contains(assetUpdates.ProjectMetadata.ThumbnailURL, "https://"), true)
+
 	// case fxhash api fail
 	//assetUpdates, err := engine.IndexTezosToken(context.Background(), "tz1NkDtLboBk6gYG2jUyLmKcQHxzDDiSU3Kn", "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE", "286488")
 	//assert.NoError(t, err)


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/1766

- [ ] Convert an IPFS link to a HTTP link when the URI is not processed by the functions using it as the input.


**Describe your changes**

- [ ] Update functions `MakeCDNURIFromIPFSURI` and `ReplaceIPFSURIByObjktCDNURI`
- [ ] Add test case for tha token.