### PR TITLE
Fix bug missing update ETH account tokens

### DIFF
--- a/services/nft-event-subscriber/ethereum.go
+++ b/services/nft-event-subscriber/ethereum.go
@@ -197,6 +197,13 @@ func (s *NFTEventSubscriber) WatchEthereumEvent(ctx context.Context) error {
 
 						go indexerWorker.StartRefreshTokenProvenanceWorkflow(ctx, &s.Worker, "subscriber", indexID, 0)
 					}
+
+					owner := map[string]int64{toAddress: 1}
+					if err := s.UpdateAccountTokenOwners(ctx, token.IndexID, timestamp, owner); err != nil {
+						log.Error("fail to update account tokens", zap.Error(err))
+						continue
+					}
+
 				}
 
 				// send notification in the end

--- a/services/nft-event-subscriber/store.go
+++ b/services/nft-event-subscriber/store.go
@@ -27,3 +27,7 @@ func (s *NFTEventSubscriber) GetTokensByIndexID(c context.Context, indexID strin
 func (s *NFTEventSubscriber) UpdateOwner(c context.Context, id, owner string, updatedAt time.Time) error {
 	return s.store.UpdateOwner(c, id, owner, updatedAt)
 }
+
+func (s *NFTEventSubscriber) UpdateAccountTokenOwners(c context.Context, indexID string, lastActivityTime time.Time, owners map[string]int64) error {
+	return s.store.UpdateAccountTokenOwners(c, indexID, lastActivityTime, owners)
+}


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/1795

- [ ] Update `account_token` when `PushProvenance` succeeds.