### PR TITLE
update mapping v2/nft to fix duplicated tokens

### DIFF
--- a/store.go
+++ b/store.go
@@ -1794,19 +1794,19 @@ func (s *MongodbIndexerStore) GetDetailedAccountTokensByOwners(ctx context.Conte
 		return nil, err
 	}
 
+	detailedTokenMap := map[string]DetailedTokenV2{}
 	results := []DetailedTokenV2{}
 
+	for _, t := range tokens {
+		detailedTokenMap[t.IndexID] = t
+	}
+
 	for _, a := range accountTokens {
-		for i := range tokens {
-			if tokens[i].IndexID == a.IndexID {
-				token := tokens[i]
-				token.Balance = a.Balance
-				token.Owner = a.OwnerAccount
-				token.LastRefreshedTime = a.LastRefreshedTime
-				results = append(results, token)
-				break
-			}
-		}
+		token := detailedTokenMap[a.IndexID]
+		token.Balance = a.Balance
+		token.Owner = a.OwnerAccount
+		token.LastRefreshedTime = a.LastRefreshedTime
+		results = append(results, token)
 	}
 
 	return results, nil


### PR DESCRIPTION
There are many account tokens with same `indexID` when query the `account_tokens`, but the result when querying in View returns non duplicated token. So we need to correct the mapping, it should follow the original list from `account_tokens` query.

**Describe your changes**

- [x] update mapping v2/nft to fix duplicated tokens

