### PR TITLE
Fix bug zero time in account tokens

### DIFF
--- a/services/nft-event-processor/server.go
+++ b/services/nft-event-processor/server.go
@@ -153,7 +153,6 @@ func (e *EventProcessor) UpdateOwnerAndProvenance(ctx context.Context) {
 					Balance:           int64(1),
 					LastActivityTime:  event.UpdatedAt,
 					LastRefreshedTime: time.Now(),
-					LastUpdatedAt:     event.UpdatedAt,
 				}
 
 				if err := e.indexerStore.IndexAccountTokens(ctx, to, []indexer.AccountToken{accountToken}); err != nil {
@@ -287,7 +286,6 @@ func (e *EventProcessor) UpdateLatestOwner(ctx context.Context) {
 				OwnerAccount:      to,
 				Balance:           int64(1),
 				LastActivityTime:  event.UpdatedAt,
-				LastUpdatedAt:     event.UpdatedAt,
 				LastRefreshedTime: time.Now(),
 			}
 

--- a/structs.go
+++ b/structs.go
@@ -223,7 +223,6 @@ type AccountToken struct {
 	LastActivityTime  time.Time        `json:"lastActivityTime" bson:"lastActivityTime"`
 	LastRefreshedTime time.Time        `json:"lastRefreshedTime" bson:"lastRefreshedTime"`
 	LastPendingTime   []time.Time      `json:"-" bson:"lastPendingTime,omitempty"`
-	LastUpdatedAt     time.Time        `json:"lastUpdatedAt" bson:"lastUpdatedAt"`
 	PendingTxs        []string         `json:"pendingTxs" bson:"pendingTxs,omitempty"`
 }
 


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/1887
- Extra information about this PR:

**Describe your changes**

- [ ] Add/update values for `lastActivityTime`, `lastRefreshedTime`, `lastUpdatedAt` of account_tokens in event processor.
- [ ] fix the missing blockchain info on events
