### PR TITLE
add provenance/ownership for minted tokens

### DIFF
--- a/background/indexerWorker/helper.go
+++ b/background/indexerWorker/helper.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bitmark-inc/nft-indexer/log"
 )
 
-func StartIndexTokenWorkflow(c context.Context, client *cadence.WorkerClient, owner, contract, tokenID string, indexPreview bool, fromEvent string) {
+func StartIndexTokenWorkflow(c context.Context, client *cadence.WorkerClient, owner, contract, tokenID string, indexProvenance, indexPreview bool) {
 	workflowContext := cadenceClient.StartWorkflowOptions{
 		ID:                           fmt.Sprintf("index-single-nft-%s-%s", contract, tokenID),
 		TaskList:                     TaskListName,
@@ -25,7 +25,7 @@ func StartIndexTokenWorkflow(c context.Context, client *cadence.WorkerClient, ow
 	var w NFTIndexerWorker
 
 	workflow, err := client.StartWorkflow(c, ClientName, workflowContext,
-		w.IndexTokenWorkflow, owner, contract, tokenID, indexPreview, fromEvent)
+		w.IndexTokenWorkflow, owner, contract, tokenID, indexProvenance, indexPreview)
 	if err != nil {
 		log.Error("fail to start indexing workflow",
 			zap.Error(err),

--- a/services/nft-event-processor/server.go
+++ b/services/nft-event-processor/server.go
@@ -178,7 +178,7 @@ func (e *EventProcessor) UpdateOwnerAndProvenance(ctx context.Context) {
 					zap.String("indexID", indexID),
 					zap.String("from", from), zap.String("to", to))
 
-				indexerWorker.StartIndexTokenWorkflow(ctx, e.worker, to, contract, tokenID, false, event.Type)
+				indexerWorker.StartIndexTokenWorkflow(ctx, e.worker, to, contract, tokenID, true, false)
 			}
 		}
 

--- a/services/nft-event-subscriber/webserver.go
+++ b/services/nft-event-subscriber/webserver.go
@@ -115,7 +115,7 @@ func (api *EventSubscriberAPI) ReceiveEvents(c *gin.Context) {
 				zap.String("from", req.From),
 				zap.String("to", req.To))
 
-			indexerWorker.StartIndexTokenWorkflow(c, &api.subscriber.Worker, req.To, req.Contract, req.TokenID, false, "")
+			indexerWorker.StartIndexTokenWorkflow(c, &api.subscriber.Worker, req.To, req.Contract, req.TokenID, false, false)
 
 			// ensure the token successfully indexed in the end
 			// if token, err = api.subscriber.GetTokensByIndexID(c, indexID); err != nil || token == nil {

--- a/services/nft-indexer/index.go
+++ b/services/nft-indexer/index.go
@@ -233,7 +233,7 @@ func (s *NFTIndexerServer) IndexOneNFT(c *gin.Context) {
 			"update": u,
 		})
 	} else {
-		indexerWorker.StartIndexTokenWorkflow(c, s.cadenceWorker, owner, contract, req.TokenID, req.Preview, "")
+		indexerWorker.StartIndexTokenWorkflow(c, s.cadenceWorker, owner, contract, req.TokenID, false, req.Preview)
 		c.JSON(200, gin.H{
 			"ok": 1,
 		})

--- a/services/nft-indexer/query.go
+++ b/services/nft-indexer/query.go
@@ -155,7 +155,7 @@ func (s *NFTIndexerServer) IndexMissingTokens(c *gin.Context, idMap map[string]b
 			continue
 		}
 
-		go indexerWorker.StartIndexTokenWorkflow(c, s.cadenceWorker, owner, contract, tokenID, false, "")
+		go indexerWorker.StartIndexTokenWorkflow(c, s.cadenceWorker, owner, contract, tokenID, false, false)
 	}
 }
 


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/2518
- Extra information about this PR:

**Checks**

- [x] Call `RefreshTokenOwnershipWorkflow` or `RefreshTokenProvenanceWorkflow` inside `IndexTokenWorkflow` as Chile workflows when the token has just been minted.


**Describe your changes**

- [ ] indexOwnershipWorkflow to call `RefreshTokenOwnershipWorkflow` as a child workflow
- [ ] indexProvenanceWorkflow to call `RefreshTokenProvenanceWorkflow` as a child workflow
- [ ] Add new parameter called `fromEvent` to `StartIndexTokenWorkflow` and `IndexTokenWorkflow`
