### PR TITLE
Add new contract support for fxhash

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -15,9 +15,10 @@ const TransferSingleEventSignature = "0xc3d58168c5ae7397731d063d5bbf3d6578544273
 const TezDaoContractAddress = "KT1C9X9s5rpVJGxwVuHEVBLYEdAQ1Qw8QDjH"
 const TezosDNSContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS"
 const KALAMContractAddress = "KT1A5P4ejnLix13jtadsfV9GCnXLMNnab8UT"
-const FXHASHContractAddress = "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE"
-const FXHASHV2ContractAddress = "KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi"
-const FXHASHOldContractAddress = "KT1AEVuykWeuuFX7QkEAMNtffzwhe1Z98hJS"
+const FXHASHContractAddressFX0_0 = "KT1U6EHmNxJTkvaWJ4ThczG4FSDaHC21ssvi"
+const FXHASHContractAddressFX0_1 = "KT1KEa8z6vWXDJrVqtMrAeDVzsvxat3kHaCE"
+const FXHASHContractAddressFX0_2 = "KT1AEVuykWeuuFX7QkEAMNtffzwhe1Z98hJS"
+const FXHASHContractAddressFX1 = "KT1EfsNuqwLAWDd3o4pvfUx1CAh5GMdTrRvr"
 const VersumContractAddress = "KT1LjmAdYQCLBjwv4S2oFkEzyHVkomAf5MrW"
 const HicEtNuncContractAddress = "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton"
 

--- a/externals/fxhash/client.go
+++ b/externals/fxhash/client.go
@@ -2,7 +2,6 @@ package fxhash
 
 import (
 	"context"
-	"math/big"
 	"net/http"
 	"time"
 
@@ -65,16 +64,16 @@ type ObjectDetail struct {
 }
 
 // This is a special type of fxhash graphql
-type ObjktId int64 //nolint
+type ObjktId string //nolint
 
 // GetObjectDetail returns an object detail for fxhash nfts
-func (api *Client) GetObjectDetail(c context.Context, id big.Int) (ObjectDetail, error) {
+func (api *Client) GetObjectDetail(c context.Context, id string) (ObjectDetail, error) {
 	var query struct {
 		Object ObjectDetail `graphql:"objkt(id: $id) "`
 	}
 
 	if err := api.client.Query(c, &query, map[string]interface{}{
-		"id": ObjktId(id.Int64()),
+		"id": ObjktId(id),
 	}); err != nil {
 		return ObjectDetail{}, err
 	}

--- a/externals/fxhash/client_test.go
+++ b/externals/fxhash/client_test.go
@@ -1,0 +1,42 @@
+package fxhash
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/bitmark-inc/nft-indexer/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	if err := log.Initialize("debug", true); err != nil {
+		panic(fmt.Errorf("fail to initialize logger with error: %s", err.Error()))
+	}
+}
+
+func TestGetObjectDetailForV0Token(t *testing.T) {
+	ctx := context.Background()
+
+	fxObjktID := "FX0-12524"
+	api := New("https://api.fxhash.xyz/graphql")
+	obj, err := api.GetObjectDetail(ctx, fxObjktID)
+	assert.NoError(t, err)
+
+	assert.Equal(t, obj.Name, "Chromatic Squares #11")
+	assert.Equal(t, obj.Issuer.Author.ID, "tz1Xx1KnngqcdWXxjaWHknEgWVcGLgStfTqv")
+	assert.Equal(t, obj.Issuer.Author.Name, "nicthib")
+}
+
+func TestGetObjectDetailForV1Token(t *testing.T) {
+	ctx := context.Background()
+
+	fxObjktID := "FX1-8739"
+	api := New("https://api.fxhash.xyz/graphql")
+	obj, err := api.GetObjectDetail(ctx, fxObjktID)
+	assert.NoError(t, err)
+
+	assert.Equal(t, obj.Name, "Brutal Nature #1")
+	assert.Equal(t, obj.Issuer.Author.ID, "KT1ASfRKswaGb3KdikjL5DwchYsn9KynHZ7G")
+	assert.Equal(t, obj.Issuer.Author.Name, "")
+}


### PR DESCRIPTION
**Description**

fxhash adds a new contract for its token. This story is to add indexing process for that contract

**Updates**

- Add the support of new fxhash contract
- Update the fxhash graphql call
- Add simple test cases
