### PR TITLE
add a command to remove null pendingTxs and lastPendingTime

### DIFF
--- a/command/remove-null-pendingTxs-fields/main.go
+++ b/command/remove-null-pendingTxs-fields/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func main() {
+	dbURIInput := flag.String("mongouri", "mongodb://localhost:27017", "mongodb uri")
+	flag.Parse()
+	dbURI := *dbURIInput
+
+	ctx := context.TODO()
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(dbURI))
+	if err != nil {
+		panic(err)
+	}
+
+	mongoCollection := client.Database("nft_indexer").Collection("account_tokens")
+	result, err := mongoCollection.UpdateMany(ctx,
+		bson.M{
+			"$or": bson.A{
+				bson.M{"pendingTxs": bson.M{"$type": 10}},
+				bson.M{"lastPendingTime": bson.M{"$type": 10}},
+			}},
+		bson.M{
+			"$unset": bson.M{"pendingTxs": "", "lastPendingTime": ""},
+		})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Updated: ", result.ModifiedCount)
+}


### PR DESCRIPTION
There are many `account_tokens` whose `pendingTx` and `lastPendingTime` are null. It cause the issue that they are not pushed new `pendingTx`.

Let's remove 2 fields in these `account_tokens`.