### PR TITLE
[externals] fix mystery OpenSea API errors

### DIFF
--- a/externals/opensea/client.go
+++ b/externals/opensea/client.go
@@ -167,7 +167,7 @@ func (c *Client) makeRequest(method, url string, body io.Reader) (*http.Response
 		return nil, err
 	}
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		// close the body only when we return an error
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusTooManyRequests {
@@ -179,7 +179,12 @@ func (c *Client) makeRequest(method, url string, body io.Reader) (*http.Response
 			return nil, err
 		}
 
-		return nil, fmt.Errorf("opensea api error: %s", errResp)
+		return nil, fmt.Errorf(
+			"opensea api error: status: %d (%s)  body: '%s'",
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode),
+			errResp,
+		)
 	}
 
 	return resp, nil


### PR DESCRIPTION
Description

-  mystery error message is seen in the feed server when indexer fails
-  all that is seen is : opensea api error: 
-  so no idea what failed

Checks

-  none

Document of the flow design and/or figma design

 -  none

Describe your changes

-  when OpenSea API call fails, return HTTP status/text in addition to body response, because body response tends to be empty
