### PR TITLE
Allow to update minted_at if the current value is zero

### DIFF
--- a/store.go
+++ b/store.go
@@ -179,7 +179,7 @@ type TokenUpdateSet struct {
 
 // checkIfTokenNeedToUpdate returns true if the new token data is suppose to be
 // better than existent one.
-func checkIfTokenNeedToUpdate(assetSource string, currentToken, newToken Token) bool {
+func checkIfTokenNeedToUpdate(assetSource string, currentToken Token) bool {
 	// ignore updates for swapped and burned token
 	if currentToken.Swapped || currentToken.Burned {
 		return false
@@ -190,9 +190,8 @@ func checkIfTokenNeedToUpdate(assetSource string, currentToken, newToken Token) 
 		return true
 	}
 
-	// assetSource is not feral file
-	// only update if token source is not feral file and token balance is greater than zero.
-	if newToken.Balance > 0 && currentToken.Source != SourceFeralFile {
+	// update only if the token source is not feral file
+	if currentToken.Source != SourceFeralFile {
 		return true
 	}
 
@@ -324,7 +323,9 @@ func (s *MongodbIndexerStore) IndexAsset(ctx context.Context, id string, assetUp
 			return err
 		}
 
-		if checkIfTokenNeedToUpdate(assetUpdates.Source, currentToken, token) {
+		if checkIfTokenNeedToUpdate(assetUpdates.Source, currentToken) {
+			log.Debug("token data need to update", zap.String("token_id", token.ID))
+
 			tokenUpdateSet := TokenUpdateSet{
 				Fungible:          token.Fungible,
 				Source:            token.Source,


### PR DESCRIPTION
**Description**

There are some chances that we can not get the minted timestamp when a token just minted from tzkt. To mitigate this, we allow the minted at be update in the future refreshing

**Describe your changes**

- [x] add minted_at in the token update set
- [x] allow update token even the balance of token is zero (with the new mechanism to index token without provide an owner, the balance will be zero in that case.)

