### PR TITLE
Add the end slash for ipfs url

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -103,7 +103,8 @@ func ipfsURLToGatewayURL(gateway, ipfsURL string) string {
 		return ipfsURL
 	}
 
-	u.Path = fmt.Sprintf("ipfs/%s%s", u.Host, u.Path)
+	// enforce a slash at the end of the path to prevent the redirect issue
+	u.Path = fmt.Sprintf("ipfs/%s%s/", u.Host, u.Path)
 	u.Host = gateway
 	u.Scheme = "https"
 


### PR DESCRIPTION
**Description**

Without a slash in the end of path, there would be a incorrect redirect for some gateways like fxhash. In order to address this, we would append a slash in the end of each path when formatting ipfs url.

**Describe your changes**

- [x] Add the end slash for ipfs url