### PR TITLE
Fallback to use the original url when image_url and animation_url are not available from opensea

### DIFF
--- a/command/add-mimetype/main.go
+++ b/command/add-mimetype/main.go
@@ -86,7 +86,7 @@ func main() {
 		}
 		fmt.Printf("\n[%v] %s-%s.\n", time.Now(), contractAddress, tokenID)
 
-		mimeType := indexer.GetMIMEType(asset.ProjectMetadata.Latest.PreviewURL)
+		mimeType := indexer.GetMIMETypeByURL(asset.ProjectMetadata.Latest.PreviewURL)
 
 		fmt.Printf("==> Mime type: %s, url: %s\n", mimeType, asset.ProjectMetadata.Latest.PreviewURL)
 

--- a/indexer_ethereum.go
+++ b/indexer_ethereum.go
@@ -130,6 +130,21 @@ func (e *IndexEngine) indexETHToken(a *opensea.Asset, owner string, balance int6
 		},
 	}
 
+	imageURL := a.ImageURL
+	if imageURL == "" {
+		imageURL = a.ImageOriginURL
+	}
+
+	imagePreviewURL := a.ImagePreviewURL
+	if imagePreviewURL == "" {
+		imagePreviewURL = a.ImageOriginURL
+	}
+
+	animationURL := a.AnimationURL
+	if animationURL == "" {
+		animationURL = a.AnimationOriginURL
+	}
+
 	metadata := ProjectMetadata{
 		ArtistID:            artistID,
 		ArtistName:          artistName,
@@ -137,21 +152,21 @@ func (e *IndexEngine) indexETHToken(a *opensea.Asset, owner string, balance int6
 		AssetID:             contractAddress,
 		Title:               a.Name,
 		Description:         a.Description,
-		MIMEType:            GetMIMEType(a.ImageURL),
+		MIMEType:            GetMIMETypeByURL(imageURL),
 		Medium:              MediumUnknown,
 		Source:              source,
 		SourceURL:           sourceURL,
-		PreviewURL:          a.ImageURL,
-		ThumbnailURL:        a.ImageURL,
-		GalleryThumbnailURL: a.ImagePreviewURL,
+		PreviewURL:          imageURL,
+		ThumbnailURL:        imageURL,
+		GalleryThumbnailURL: imagePreviewURL,
 		AssetURL:            a.Permalink,
 		LastUpdatedAt:       time.Now(),
 		Artists:             artists,
 	}
 
-	if a.AnimationURL != "" {
-		metadata.PreviewURL = a.AnimationURL
-		metadata.MIMEType = GetMIMEType(a.AnimationURL)
+	if animationURL != "" {
+		metadata.PreviewURL = animationURL
+		metadata.MIMEType = GetMIMETypeByURL(animationURL)
 
 		if source == sourceArtBlocks {
 			metadata.Medium = MediumSoftware
@@ -160,7 +175,7 @@ func (e *IndexEngine) indexETHToken(a *opensea.Asset, owner string, balance int6
 			log.Debug("fallback medium check", zap.String("previewURL", metadata.PreviewURL), zap.Any("medium", medium))
 			metadata.Medium = medium
 		}
-	} else if a.ImageURL != "" {
+	} else if imageURL != "" {
 		metadata.Medium = MediumImage
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -121,8 +121,8 @@ func CheckCDNURLIsExist(url string) bool {
 	return false
 }
 
-// GetMIMEType returns mimeType of a file based on the extension of the url
-func GetMIMEType(urlString string) string {
+// GetMIMETypeByURL returns mimeType of a file based on the extension of the url
+func GetMIMETypeByURL(urlString string) string {
 	u, err := url.Parse(urlString)
 	if err != nil {
 		return ""

--- a/utils_test.go
+++ b/utils_test.go
@@ -22,19 +22,19 @@ func TestParseTokenIndexID(t *testing.T) {
 
 func TestGetMIMEType(t *testing.T) {
 	url := "https://i.seadn.io/gcs/files/bbc0a44987656c60494fd646e0f670d0.gif?w=500&auto=format"
-	mimeType := GetMIMEType(url)
+	mimeType := GetMIMETypeByURL(url)
 	assert.Equal(t, mimeType, "image/gif")
 
 	url = "https://i.seadn.io/gcs/files/d2fe56690de325daa49cad0600304345.png"
-	mimeType = GetMIMEType(url)
+	mimeType = GetMIMETypeByURL(url)
 	assert.Equal(t, mimeType, "image/png")
 
 	url = "https://i.seadn.io/gcs/files/669bd5d03542a1a8fb9b6587e2103ae7.png?w=500&auto=format"
-	mimeType = GetMIMEType(url)
+	mimeType = GetMIMETypeByURL(url)
 	assert.Equal(t, mimeType, "image/png")
 
 	url = "https://ipfs.io/ipfs/QmbNtTu7k2E2UDYDQTyiVzV8rVbCU44hc9js1erKzeSogY"
-	mimeType = GetMIMEType(url)
+	mimeType = GetMIMETypeByURL(url)
 	assert.Equal(t, mimeType, "")
 }
 


### PR DESCRIPTION
**Description**

Some tokens from opensea returns `null` for image_url. In this case, we should try to fallback to the original url from opensea's response

**Describe your changes**

- [x] Rename `GetMIMEType` to `GetMIMETypeByURL`
- [x] fallback urls if necessary