### PR TITLE
Fix the max message byte

### DIFF
--- a/services/nft-event-processor-tezos-emitter/service.go
+++ b/services/nft-event-processor-tezos-emitter/service.go
@@ -18,6 +18,8 @@ import (
 	"github.com/bitmark-inc/nft-indexer/services/nft-event-processor/grpc/processor"
 )
 
+const maxMessageSize = 1 << 20 // 1MiB
+
 type TezosEventsEmitter struct {
 	lastBlockKeyName string
 	parameterStore   *ssm.ParameterStore
@@ -108,6 +110,7 @@ func (s *SignalrLogger) Log(keyVals ...interface{}) error {
 func (e *TezosEventsEmitter) Run(ctx context.Context) {
 	client, err := signalr.NewClient(ctx,
 		signalr.Logger(&SignalrLogger{}, viper.GetBool("debug")),
+		signalr.MaximumReceiveMessageSize(maxMessageSize),
 		signalr.WithConnector(func() (signalr.Connection, error) {
 			creationCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()


### PR DESCRIPTION
**Description**

-Fix connection closed with unexpected message bytes

**Describe your changes**

- [ ] change the message read limit to 1 MiB (default

**Error log**

```json!
[
    {
        "level": "info",
        "ts": "2023-09-08T16:03:56.894679824Z",
        "caller": "nft-event-processor-tezos-emitter/service.go:102",
        "msg": "signalr log",
        "class": "Client",
        "connection": "w2cPLJqxQK11vL639Mj8mg",
        "hub": "main.TezosEventsEmitter",
        "{<nil> 0xc0000cb1c0}": "message received",
        "error": "*signalr.webSocketConnection: failed to read: read limited at 32769 bytes",
        "message": "<nil>",
        "reaction": "close connection"
    },
    {
        "level": "info",
        "ts": "2023-09-08T16:03:56.894845948Z",
        "caller": "nft-event-processor-tezos-emitter/service.go:102",
        "msg": "signalr log",
        "connect": "*signalr.webSocketConnection: failed to read: read limited at 32769 bytes"
    }
]
```
