### PR TITLE
Improve the pending txs following workflow

### DIFF
--- a/background/worker/context.go
+++ b/background/worker/context.go
@@ -24,12 +24,40 @@ func ContextRetryActivity(ctx workflow.Context, taskList string) workflow.Contex
 	return workflow.WithActivityOptions(ctx, ao)
 }
 
+func ContextFastActivity(ctx workflow.Context, taskList string) workflow.Context {
+	ao := workflow.ActivityOptions{
+		TaskList:               taskList,
+		ScheduleToStartTimeout: 10 * time.Second,
+		StartToCloseTimeout:    1 * time.Minute,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:    1 * time.Second,
+			BackoffCoefficient: 1.0,
+			MaximumAttempts:    6,
+		},
+	}
+
+	if taskList != "" {
+		ao.TaskList = taskList
+	}
+
+	return workflow.WithActivityOptions(ctx, ao)
+}
+
 // ContextRegularActivity returns a regular activity context
 func ContextRegularActivity(ctx workflow.Context, taskList string) workflow.Context {
 	ao := workflow.ActivityOptions{
 		TaskList:               taskList,
 		ScheduleToStartTimeout: time.Minute,
 		StartToCloseTimeout:    5 * time.Minute,
+		RetryPolicy: &cadence.RetryPolicy{
+			InitialInterval:    5 * time.Second,
+			BackoffCoefficient: 1.0,
+			MaximumAttempts:    10,
+		},
+	}
+
+	if taskList != "" {
+		ao.TaskList = taskList
 	}
 
 	return workflow.WithActivityOptions(ctx, ao)

--- a/scripts/init_mongodb.js
+++ b/scripts/init_mongodb.js
@@ -130,6 +130,8 @@ db.account_tokens.createIndexes([{
   "lastActivityTime": -1
 }, {
   "lastRefreshedTime": -1
+}, {
+  "pendingTxs": 1
 }])
 
 

--- a/services/nft-account-token-indexer/main.go
+++ b/services/nft-account-token-indexer/main.go
@@ -103,6 +103,8 @@ func main() {
 	// activities
 	activity.Register(worker.GetTxTimestamp)
 	activity.Register(worker.GetPendingAccountTokens)
+	activity.Register(worker.GetTokenBalanceOfOwner)
+	activity.Register(worker.IndexAccountTokens)
 	activity.Register(worker.UpdatePendingTxsToAccountToken)
 	activity.Register(worker.CalculateMIMETypeFromTokenFeedback)
 	activity.Register(worker.UpdatePresignedThumbnailAssets)

--- a/store.go
+++ b/store.go
@@ -1306,7 +1306,7 @@ func (s *MongodbIndexerStore) IndexAccount(ctx context.Context, account Account)
 func (s *MongodbIndexerStore) IndexAccountTokens(ctx context.Context, owner string, accountTokens []AccountToken) error {
 	margin := 15 * time.Second
 	for _, accountToken := range accountTokens {
-		log.Debug("account token is in a future state", zap.String("indexID", accountToken.IndexID), zap.Any("accountToken", accountToken))
+		log.Debug("update account token", zap.String("indexID", accountToken.IndexID), zap.Any("accountToken", accountToken))
 		r, err := s.accountTokenCollection.UpdateOne(ctx,
 			bson.M{"indexID": accountToken.IndexID, "ownerAccount": owner, "lastActivityTime": bson.M{"$lt": accountToken.LastActivityTime.Add(-margin)}},
 			bson.M{"$set": accountToken},
@@ -1325,7 +1325,8 @@ func (s *MongodbIndexerStore) IndexAccountTokens(ctx context.Context, owner stri
 		}
 		if r.MatchedCount == 0 && r.UpsertedCount == 0 {
 			// TODO: not sure when will this happen. Figure this our later
-			log.Warn("account token is not added or updated", zap.String("token_id", accountToken.ID))
+			log.Warn("account token is not added or updated",
+				zap.String("ownerAccount", owner), zap.String("indexID", accountToken.IndexID))
 		}
 	}
 


### PR DESCRIPTION

**Description**

- The pending token following process would blocked by certain long-run ownership sync process (180000 owners)
- Not only rely on full-sync of `RefreshToken(Provenance/Ownership)Workflow` to update the token balance 

**Describe your changes**

- Fix the unexpected break of error handling for transaction checking
- Update the token balance immediately for tokens attached with new detected transaction
- Make the token full ownership / provenance refreshing be an asynchronous task

