### PR TITLE
Refresh account tokens for an owner on IndexXXXTokenForOwners

### DIFF
--- a/background/worker/activities.go
+++ b/background/worker/activities.go
@@ -208,6 +208,10 @@ func (w *NFTIndexerWorker) MarkAccountTokenChanged(ctx context.Context, indexIDs
 	return w.indexerStore.MarkAccountTokenChanged(ctx, indexIDs)
 }
 
+func (w *NFTIndexerWorker) MarkAccountTokenChangedByOwner(ctx context.Context, owner string) error {
+	return w.indexerStore.MarkAccountTokenChangedByOwner(ctx, owner)
+}
+
 type Provenance struct {
 	TxID      string    `json:"tx_id"`
 	Owner     string    `json:"owner"`

--- a/services/nft-indexer-background/main.go
+++ b/services/nft-indexer-background/main.go
@@ -118,6 +118,7 @@ func main() {
 	// index account tokens
 	activity.Register(worker.IndexAccountTokens)
 	activity.Register(worker.MarkAccountTokenChanged)
+	activity.Register(worker.MarkAccountTokenChangedByOwner)
 
 	workerServiceClient := cadence.BuildCadenceServiceClient(hostPort, indexerWorker.ClientName, CadenceService)
 	cadence.StartWorker(log.DefaultLogger(), workerServiceClient, viper.GetString("cadence.domain"), indexerWorker.TaskListName)

--- a/services/nft-provenance-indexer/main.go
+++ b/services/nft-provenance-indexer/main.go
@@ -105,7 +105,6 @@ func main() {
 	activity.Register(worker.FilterTokenIDsWithInconsistentProvenanceForOwner)
 	activity.Register(worker.RefreshTokenProvenance)
 	activity.Register(worker.RefreshTokenOwnership)
-	activity.Register(worker.MarkAccountTokenChanged)
 
 	workerServiceClient := cadence.BuildCadenceServiceClient(hostPort, indexerWorker.ClientName, CadenceService)
 	cadence.StartWorker(log.DefaultLogger(), workerServiceClient, viper.GetString("cadence.domain"), indexerWorker.ProvenanceTaskListName)


### PR DESCRIPTION
**Description**

- Related story link: https://github.com/bitmark-inc/au-support-board/issues/1778
- The last refresh time would not update if a token's activity time has already been the latest time.

**Describe your changes**

- [ ] Add an activity MarkAccountTokenChangedByOwner
- [ ] Update the token refresh time on token indexing by owner
