### PR TITLE
Use thumbnail for twitter 

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -188,8 +188,9 @@ type AssetMetadataDetail struct {
 	ArtistURL  string
 	MaxEdition int64
 
-	DisplayURI string
-	PreviewURI string
+	ThumbnailURI string
+	DisplayURI   string
+	PreviewURI   string
 
 	IsBooleanAmount bool
 
@@ -251,7 +252,7 @@ func (detail *AssetMetadataDetail) FromTZIP21TokenMetadata(md tzkt.TokenMetadata
 		}
 	}
 
-	var displayURI, previewURI string
+	var thumbnailURI, displayURI, previewURI string
 
 	if optimizedDisplayURI != "" {
 		displayURI = optimizedDisplayURI
@@ -261,6 +262,11 @@ func (detail *AssetMetadataDetail) FromTZIP21TokenMetadata(md tzkt.TokenMetadata
 		displayURI = md.ThumbnailURI
 	} else {
 		displayURI = DefaultDisplayURI
+	}
+
+	// set default thumbnailURI to md.ThumbnailURI and fallback to displayURI if thumbnailURI is empty
+	if thumbnailURI = md.ThumbnailURI; thumbnailURI == "" {
+		thumbnailURI = displayURI
 	}
 
 	if md.ArtifactURI != "" {
@@ -287,6 +293,7 @@ func (detail *AssetMetadataDetail) FromTZIP21TokenMetadata(md tzkt.TokenMetadata
 		detail.Source = md.Publishers[0]
 	}
 
+	detail.ThumbnailURI = thumbnailURI
 	detail.DisplayURI = displayURI
 	detail.PreviewURI = previewURI
 
@@ -322,6 +329,7 @@ func (detail *AssetMetadataDetail) FromFxhashObject(o fxhash.ObjectDetail) {
 	detail.Name = o.Name
 	detail.Description = o.Metadata.Description
 	detail.MaxEdition = o.Issuer.Supply
+	detail.ThumbnailURI = ipfsURLToGatewayURL(FxhashGateway, o.Metadata.ThumbnailURI)
 	detail.DisplayURI = ipfsURLToGatewayURL(FxhashGateway, o.Metadata.DisplayURI)
 	detail.PreviewURI = ipfsURLToGatewayURL(FxhashGateway, o.Metadata.ArtifactURI)
 	detail.Artists = artists
@@ -417,6 +425,8 @@ func (detail *AssetMetadataDetail) UpdateMetadataFromObjkt(token objkt.Token) {
 	if detail.DisplayURI == "" || detail.DisplayURI == hicetnuncDefaultThumbnailURL {
 		detail.DisplayURI = ipfsURLToGatewayURL(DefaultIPFSGateway, DefaultDisplayURI)
 	}
+
+	detail.ThumbnailURI = detail.DisplayURI
 
 	if token.ArtifactURI != "" {
 		detail.PreviewURI = detail.ReplaceIPFSURIByObjktCDNURI(ObjktCDNArtifactType, token.ArtifactURI, token.FaContract, token.TokenID)

--- a/indexer_tezos.go
+++ b/indexer_tezos.go
@@ -349,6 +349,7 @@ func (e *IndexEngine) indexTezosToken(ctx context.Context, tzktToken tzkt.Token,
 	}
 
 	// ensure ipfs urls are converted to http links
+	metadataDetail.ThumbnailURI = ipfsURLToGatewayURL(gateway, metadataDetail.ThumbnailURI)
 	metadataDetail.DisplayURI = ipfsURLToGatewayURL(gateway, metadataDetail.DisplayURI)
 	metadataDetail.PreviewURI = ipfsURLToGatewayURL(gateway, metadataDetail.PreviewURI)
 
@@ -369,8 +370,10 @@ func (e *IndexEngine) indexTezosToken(ctx context.Context, tzktToken tzkt.Token,
 		Artists:    metadataDetail.Artists,
 		MaxEdition: metadataDetail.MaxEdition,
 
-		PreviewURL:          metadataDetail.PreviewURI,
-		ThumbnailURL:        metadataDetail.DisplayURI,
+		PreviewURL: metadataDetail.PreviewURI,
+		// use the thumbnail in metadata for ThumbnailURL
+		ThumbnailURL: metadataDetail.ThumbnailURI,
+		// use the high quality image for GalleryThumbnailURL
 		GalleryThumbnailURL: metadataDetail.DisplayURI,
 
 		ArtworkMetadata: metadataDetail.ArtworkMetadata,


### PR DESCRIPTION
**Description**

To support different dimension of thumbnail image in X, we separate the image source of `ThumbnailURL` and `GalleryThumbnailURL` on indexing.

**Changes**

- index thumbnail url from token metadata
- add the dev minter into inhouse minter
- ensure dev postcard token data would not override by objkt data on indexing
