### PR TITLE
Use the number of #{number} in artwork name as edition number for ethereum

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -521,6 +522,25 @@ func MakeCDNURIFromIPFSURI(assetURI, assetType, contract, tokenID string) (strin
 	}
 
 	return ipfsURLToGatewayURL(DefaultIPFSGateway, assetURI), nil
+}
+
+// GetEditionNumberByName inferences the edition number by the format #{numbers}
+func (e *IndexEngine) GetEditionNumberByName(name string) int64 {
+
+	r := regexp.MustCompile(`.*#(\d+)$`)
+
+	matchArray := r.FindStringSubmatch(name)
+
+	if len(matchArray) < 2 {
+		return 0
+	}
+	// matchArray[0] is the whole string.
+	n, err := strconv.ParseInt(matchArray[1], 10, 0)
+	if err != nil {
+		return 0
+	}
+
+	return n
 }
 
 // GetTxTimestamp returns transaction timestamp of a blockchain

--- a/indexer_ethereum.go
+++ b/indexer_ethereum.go
@@ -238,7 +238,7 @@ func (e *IndexEngine) indexETHToken(a *opensea.Asset, owner string, balance int6
 			ContractAddress: contractAddress,
 		},
 		IndexID:           TokenIndexID(utils.EthereumBlockchain, contractAddress, a.TokenID),
-		Edition:           0,
+		Edition:           e.GetEditionNumberByName(a.Name),
 		Balance:           balance,
 		Owner:             owner,
 		MintedAt:          a.AssetContract.CreatedDate.Time, // set minted_at to the contract creation time

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -70,3 +70,11 @@ func TestGetTokenBalanceOfOwner(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(4), balance3)
 }
+
+func TestGetEditionNumberByName(t *testing.T) {
+	engine := &IndexEngine{}
+	n1 := engine.GetEditionNumberByName("test 123")
+	assert.Equal(t, int64(0), n1)
+	n2 := engine.GetEditionNumberByName("test #123")
+	assert.Equal(t, int64(123), n2)
+}


### PR DESCRIPTION
**Description**

- Use the number of #{number} in artwork name as edition number for ethereum
