### PR TITLE
Fix opensea cached content non existent issue

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -76,16 +75,22 @@ func getTokenSourceByPreviewURL(url string) string {
 	return ""
 }
 
-// getOpenseaCachedImageFileName get the filename by inspect opensea's cdn link.
-func getOpenseaCachedImageFileName(imageURL string) (string, error) {
+// OptimizedOpenseaImageURL get the filename by inspect opensea's cdn link.
+func OptimizedOpenseaImageURL(imageURL string) (string, error) {
 	u, err := url.Parse(imageURL)
 	if err != nil {
-		return "", err
+		return imageURL, err
 	}
-	if u.Host == "i.seadn.io" && strings.Contains(u.Path, "files/") {
-		return path.Base(u.Path), nil
+
+	if u.Host == "i.seadn.io" {
+		u.RawQuery = url.Values{
+			"auto": []string{"format"},
+			"dpr":  []string{"1"},
+			"w":    []string{"3840"},
+		}.Encode()
 	}
-	return "", nil
+
+	return u.String(), nil
 }
 
 // mediumByPreviewFileExtension returns token medium by detecting file extension

--- a/indexer_ethereum.go
+++ b/indexer_ethereum.go
@@ -159,16 +159,9 @@ func (e *IndexEngine) indexETHToken(a *opensea.Asset, owner string, balance int6
 		},
 	}
 
-	imageURL := a.ImageURL
-
-	openseaFilename, err := getOpenseaCachedImageFileName(imageURL)
+	imageURL, err := OptimizedOpenseaImageURL(a.ImageURL)
 	if err != nil {
-		log.Warn("invalid opensea image url", zap.String("imageURL", imageURL))
-	}
-
-	// abstract opensea stored original image url
-	if openseaFilename != "" {
-		imageURL = "https://openseauserdata.com/files/" + openseaFilename
+		log.Warn("invalid opensea image url", zap.String("imageURL", a.ImageURL))
 	}
 
 	// fallback to project origin image url

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -70,3 +70,18 @@ func TestGetTokenBalanceOfOwner(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(4), balance3)
 }
+
+func TestOptimizedOpenseaImageURL(t *testing.T) {
+	newURL1, err := OptimizedOpenseaImageURL("https://i.seadn.io/s/raw/files/aed53e1bcd90ca93b6fd3b0e012fadc5.jpg?w=500&auto=format")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://i.seadn.io/s/raw/files/aed53e1bcd90ca93b6fd3b0e012fadc5.jpg?auto=format&dpr=1&w=3840", newURL1)
+
+	newURL2, err := OptimizedOpenseaImageURL("https://i.seadn.io/gcs/files/0d06a393468f2e227ed14a6a88f951bc.jpg?w=500&auto=format")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://i.seadn.io/gcs/files/0d06a393468f2e227ed14a6a88f951bc.jpg?auto=format&dpr=1&w=3840", newURL2)
+
+	newURL3, err := OptimizedOpenseaImageURL("https://i.seadn.io/gae/zxrPTPWKa-uc-oLImHUN_bst5e6v7zeL5AIDXn1LWTpVe_43oCG2i-sZ5IsFHxHt4pkIuoDeaZF1HnApLqdy9wrzSeKSepRyYOr_9Q?w=500&auto=format")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://i.seadn.io/gae/zxrPTPWKa-uc-oLImHUN_bst5e6v7zeL5AIDXn1LWTpVe_43oCG2i-sZ5IsFHxHt4pkIuoDeaZF1HnApLqdy9wrzSeKSepRyYOr_9Q?auto=format&dpr=1&w=3840", newURL3)
+
+}


### PR DESCRIPTION
**Description**

Fix opensea cached content non existent issue since opensea introduce another different caching path

- change to override the cdn parameter instead of change the source
- update for all image resources in `i.seadn.io`