### PR TITLE
check fxhash source by metadata url

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -81,6 +81,15 @@ func getTokenSourceByPreviewURL(url string) string {
 	return ""
 }
 
+// getTokenSourceByMetadataURL returns the token source name by inspecting the metadata url
+func getTokenSourceByMetadataURL(url string) string {
+	if fxhashMatched, _ := regexp.MatchString(`media.fxhash.xyz`, url); fxhashMatched {
+		return sourceFxHash
+	}
+
+	return ""
+}
+
 // OptimizedOpenseaImageURL get the filename by inspect opensea's cdn link.
 func OptimizedOpenseaImageURL(imageURL string) (string, error) {
 	u, err := url.Parse(imageURL)
@@ -158,12 +167,12 @@ func ipfsURLToGatewayURL(gateway, ipfsURL string) string {
 	return u.String()
 }
 
-func OptimizeFxHashImageURL(imageURL string) string {
-	if strings.Contains(imageURL, "https://ipfs.io/ipfs/") {
-		return strings.ReplaceAll(imageURL, "ipfs.io", FxhashGateway)
+func OptimizeFxHashIPFSURL(url string) string {
+	if strings.Contains(url, "https://ipfs.io/ipfs/") {
+		return strings.ReplaceAll(url, "ipfs.io", FxhashGateway)
 	}
 
-	return imageURL
+	return url
 }
 
 func IsIPFSLink(url string) bool {

--- a/indexer_ethereum.go
+++ b/indexer_ethereum.go
@@ -126,7 +126,12 @@ func (e *IndexEngine) indexETHToken(a *opensea.DetailedAssetV2, owner string, ba
 		return nil, nil
 	}
 
-	source := getTokenSourceByPreviewURL(a.AnimationURL)
+	source := getTokenSourceByMetadataURL(a.MetadataURL)
+
+	if source == "" {
+		source = getTokenSourceByPreviewURL(a.AnimationURL)
+	}
+
 	if source == "" {
 		source = getTokenSourceByContract(contractAddress)
 	}
@@ -162,6 +167,7 @@ func (e *IndexEngine) indexETHToken(a *opensea.DetailedAssetV2, owner string, ba
 	}
 
 	assetURL := a.OpenseaURL
+	animationURL := a.AnimationURL
 
 	imageURL, err := OptimizedOpenseaImageURL(a.ImageURL)
 	if err != nil {
@@ -175,10 +181,9 @@ func (e *IndexEngine) indexETHToken(a *opensea.DetailedAssetV2, owner string, ba
 
 	if source == sourceFxHash {
 		assetURL = fmt.Sprintf("https://www.fxhash.xyz/gentk/%s-%s", a.Contract, a.Identifier)
-		imageURL = OptimizeFxHashImageURL(imageURL)
+		imageURL = OptimizeFxHashIPFSURL(imageURL)
+		animationURL = OptimizeFxHashIPFSURL(animationURL)
 	}
-
-	animationURL := a.AnimationURL
 
 	metadata := ProjectMetadata{
 		ArtistID:            artistID,


### PR DESCRIPTION
**Description**

- Some fxhash tokens are still having `ipfs.io` in the `previewURL`. Switched to use `metadataURL` to check the fxhash source
