### PR TITLE
Create all thumbnails

### DIFF
--- a/services/nft-image-indexer/service.go
+++ b/services/nft-image-indexer/service.go
@@ -114,14 +114,12 @@ func (s *NFTContentIndexer) getAssetWithoutThumbnailCached(ctx context.Context) 
 
 			// filter recent assets which have not been processed or are not timestamped
 			//"thumbnailLastCheck": bson.M{"$lt": time.Now().Add(-s.thumbnailCacheRetryInterval)},
-			bson.M{
-				"$or": bson.A{
-					bson.M{ // this will be false of any non time values
-						"thumbnailLastCheck": bson.M{"$lt": ts},
-					},
-					bson.M{ // include null and empty string to cover both defaults
-						"thumbnailLastCheck": bson.M{"$in": bson.A{nil, ""}},
-					},
+			"$or": bson.A{
+				bson.M{ // this will be false of any non time values
+					"thumbnailLastCheck": bson.M{"$lt": ts},
+				},
+				bson.M{ // include null and empty string to cover both defaults
+					"thumbnailLastCheck": bson.M{"$in": bson.A{nil, ""}},
 				},
 			},
 


### PR DESCRIPTION
**Description**

change image indexer query to find all assets missing thumbnailID UNLESS:
- timestamp indicates was tried within cache interval
- has recorded a failed attempt